### PR TITLE
refactor(server): store project/config names as plaintext

### DIFF
--- a/docs/01-architecture.md
+++ b/docs/01-architecture.md
@@ -11,7 +11,7 @@ Think of it as a self-hosted Doppler/Infisical that fits inside one Cloudflare W
 ## Core Principles
 
 1. **Single deployment target** — One Worker, one D1 database, one master secret. Nothing else.
-2. **Zero trust storage** — All secret values and keys are encrypted at rest with AES-256-GCM. API keys are hashed with SHA-256. Even with full DB access, an attacker learns nothing.
+2. **Zero trust storage** — Secret keys and values are encrypted at rest with AES-256-GCM. API keys are hashed with SHA-256. Even with full DB access, secret contents remain protected.
 3. **Minimal surface area** — No users, no sessions, no OAuth. Just API keys with scoped permissions.
 4. **Simple mental model** — Projects → Environments → Key/Value secrets. That's it. New projects get two default environments (**Dev** and **Prod**) unless created with the `environmentless` option (API) or `--environmentless` flag (CLI).
 
@@ -114,8 +114,7 @@ apiKeys: {
 // projects
 projects: {
   id              text PK
-  name_encrypted  text NOT NULL       -- AES-256-GCM encrypted
-  name_hash       text NOT NULL UNIQUE -- HMAC-SHA256 for lookups
+  name            text NOT NULL UNIQUE -- plaintext project name
   created_at      text NOT NULL
 }
 
@@ -125,10 +124,9 @@ projects: {
 environments: {
   id              text PK
   project_id      text → projects.id ON DELETE CASCADE
-  name_encrypted  text NOT NULL       -- AES-256-GCM encrypted
-  name_hash       text NOT NULL       -- HMAC-SHA256 for lookups
+  name            text NOT NULL       -- plaintext environment name
   created_at      text NOT NULL
-  UNIQUE(project_id, name_hash)
+  UNIQUE(project_id, name)
 }
 
 // secrets
@@ -159,8 +157,8 @@ CLI (kfl)                         Keyflare Worker                    D1
    │                                    │  3. Verify key + scopes    │
    │                                    │<────────────────────────────│
    │                                    │                             │
-   │                                    │  4. HMAC project+env names │
-   │                                    │  5. Query secrets by hash  │
+   │                                    │  4. Look up project+env by name │
+   │                                    │  5. Query secrets by env id     │
    │                                    │────────────────────────────>│
    │                                    │<────────────────────────────│
    │                                    │                             │
@@ -183,7 +181,7 @@ CLI (kfl)                         Keyflare Worker                    D1
 | Database           | Cloudflare D1 (SQLite)        | Zero config, co-located with Worker, SQL support                                                              |
 | Encryption         | AES-256-GCM (Web Crypto API)  | Available natively in Workers runtime, authenticated encryption                                               |
 | Hashing (API keys) | SHA-256 (Web Crypto API)      | API keys have 128-bit entropy — brute-force infeasible regardless of hash speed. Native, zero dependencies.   |
-| Hashing (lookups)  | HMAC-SHA256                   | Deterministic, keyed — allows lookups without exposing plaintext                                              |
+| Hashing (lookups)  | HMAC-SHA256                   | Deterministic keyed lookup for `secrets.key_hash` without storing plaintext secret keys                       |
 | CLI framework      | Commander.js                  | Mature, TypeScript-native, great DX                                                                           |
 | ORM / migrations   | Drizzle ORM + drizzle-kit     | Type-safe queries inferred from schema; generates versioned SQL migrations                                    |
 | CLI UI             | chalk, ora, @inquirer/prompts | Coloured output, spinners, interactive prompts                                                                |

--- a/docs/02-security-model.md
+++ b/docs/02-security-model.md
@@ -6,7 +6,7 @@ Keyflare assumes the following threat scenarios:
 
 | Threat | Mitigation |
 |--------|-----------|
-| D1 database dump / leak | All secret values, secret keys, and project/environment names are **AES-256-GCM encrypted**. API keys are **hashed**. Raw DB data is useless. |
+| D1 database dump / leak | Secret values and secret keys are **AES-256-GCM encrypted**. API keys are **hashed**. Project/environment names are plaintext metadata. |
 | API key theft | Keys are scoped — a system key can only access specific project/environment combinations. Revocation is instant. |
 | Network interception | All traffic to Cloudflare Workers is TLS-encrypted (HTTPS enforced). |
 | Master key compromise | Single point of failure by design. See [Master Key Management](#master-key-management). |
@@ -51,9 +51,9 @@ We use **HKDF (HMAC-based Key Derivation Function)** to derive two separate keys
 
 This separation ensures that even if the HMAC key were somehow exposed, the encryption key remains independent.
 
-### Symmetric Encryption — Secret Values
+### Symmetric Encryption — Secret Material
 
-All sensitive data in D1 is encrypted with **AES-256-GCM**:
+Sensitive secret material in D1 is encrypted with **AES-256-GCM**:
 
 ```
 Encrypt(plaintext):
@@ -73,14 +73,14 @@ Decrypt(stored):
 **What gets encrypted:**
 - Secret values (`DB_PASSWORD=hunter2`)
 - Secret key names (`DB_PASSWORD`)
-- Project names
-- Environment names
 - API key labels
 - System key scope definitions
 
 **What is NOT encrypted (by design):**
 - Row IDs (UUIDs, no information leakage)
 - Timestamps (created_at, updated_at)
+- Project names
+- Environment names
 - API key type (`user` / `system`)
 - API key permission level (`read` / `readwrite`)
 - Revocation status
@@ -97,8 +97,6 @@ LookupHash(name):
 ```
 
 This is used for:
-- `projects.name_hash` — find project by name
-- `environments.name_hash` — find environment by name within a project
 - `secrets.key_hash` — find/upsert secret by key name within an environment
 
 HMAC is deterministic (same input → same hash) but keyed, so it's not reversible without the HMAC key.
@@ -303,12 +301,12 @@ A hardcoded development key is acceptable because local D1 is ephemeral and cont
 │  │ D1 Database                                                   │ │
 │  │                                                                │ │
 │  │  Contains ONLY:                                                │ │
-│  │  - Encrypted blobs (AES-256-GCM)                              │ │
+│  │  - Encrypted secret/key blobs (AES-256-GCM)                   │ │
 │  │  - HMAC hashes (for lookups)                                   │ │
 │  │  - SHA-256 hashes (API keys)                                   │ │
 │  │  - Non-sensitive metadata (timestamps, UUIDs, types)           │ │
 │  │                                                                │ │
-│  │  A full database dump reveals NOTHING about secret contents.   │ │
+│  │  A full database dump still hides secret values and key names. │ │
 │  └────────────────────────────────────────────────────────────────┘ │
 │                                                                     │
 └─────────────────────────────────────────────────────────────────────┘

--- a/docs/06-development.md
+++ b/docs/06-development.md
@@ -252,7 +252,7 @@ npx wrangler d1 execute keyflare-db --remote \
   --command "SELECT id, key_prefix, type FROM api_keys"
 ```
 
-Note: all `label`, `scopes`, `name_encrypted`, `key_encrypted`, and `value_encrypted` columns contain AES-256-GCM ciphertext — they are unreadable without the MASTER_KEY.
+Note: `label`, `scopes`, `key_encrypted`, and `value_encrypted` columns contain AES-256-GCM ciphertext — they are unreadable without the MASTER_KEY. Project/config names are stored in plaintext `name` columns.
 
 ---
 

--- a/docs/07-deployment.md
+++ b/docs/07-deployment.md
@@ -129,7 +129,7 @@ curl -X POST https://keyflare.<account>.workers.dev/bootstrap
             │  └───────┬───────┘  │
             │          │          │
             │  ┌───────▼───────┐  │
-            │  │   D1 (SQLite) │  │  ← Single database, encrypted data
+            │  │   D1 (SQLite) │  │  ← Single database, encrypted secret data
             │  │   keyflare-db │  │
             │  └───────────────┘  │
             │                     │
@@ -240,7 +240,7 @@ npx wrangler d1 export keyflare-db --output backup.sql
 
 ### Master Key Backup
 
-**The MASTER_KEY is the single most critical piece of infrastructure.** Without it, all encrypted data is permanently unrecoverable — there is no backdoor.
+**The MASTER_KEY is the single most critical piece of infrastructure.** Without it, encrypted secret data is permanently unrecoverable — there is no backdoor.
 
 Recommended storage:
 1. Password manager (1Password, Bitwarden)

--- a/docs/diagrams/flows.md
+++ b/docs/diagrams/flows.md
@@ -213,16 +213,14 @@ erDiagram
 
     PROJECTS {
         text id PK
-        text name_encrypted
-        text name_hash UK
+        text name UK
         text created_at
     }
 
     ENVIRONMENTS {
         text id PK
         text project_id FK
-        text name_encrypted
-        text name_hash
+        text name
         text created_at
     }
 
@@ -259,7 +257,7 @@ graph TB
     end
 
     subgraph "Layer 4: Encryption at Rest"
-        ENC[AES-256-GCM<br/>All data encrypted in D1]
+        ENC[AES-256-GCM<br/>Secrets and key metadata encrypted in D1]
         HMAC[HMAC-SHA256<br/>Keyed hashes for lookups]
     end
 

--- a/packages/server/migrations/0001_plaintext-project-config-names.sql
+++ b/packages/server/migrations/0001_plaintext-project-config-names.sql
@@ -1,0 +1,35 @@
+DROP TABLE IF EXISTS `secrets`;
+--> statement-breakpoint
+DROP TABLE IF EXISTS `environments`;
+--> statement-breakpoint
+DROP TABLE IF EXISTS `projects`;
+--> statement-breakpoint
+CREATE TABLE `projects` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`created_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `projects_name_unique` ON `projects` (`name`);
+--> statement-breakpoint
+CREATE TABLE `environments` (
+	`id` text PRIMARY KEY NOT NULL,
+	`project_id` text NOT NULL,
+	`name` text NOT NULL,
+	`created_at` text NOT NULL,
+	FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `environments_project_id_name_unique` ON `environments` (`project_id`,`name`);
+--> statement-breakpoint
+CREATE TABLE `secrets` (
+	`id` text PRIMARY KEY NOT NULL,
+	`environment_id` text NOT NULL,
+	`key_encrypted` text NOT NULL,
+	`key_hash` text NOT NULL,
+	`value_encrypted` text NOT NULL,
+	`updated_at` text NOT NULL,
+	FOREIGN KEY (`environment_id`) REFERENCES `environments`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `secrets_environment_id_key_hash_unique` ON `secrets` (`environment_id`,`key_hash`);

--- a/packages/server/migrations/meta/0001_snapshot.json
+++ b/packages/server/migrations/meta/0001_snapshot.json
@@ -1,0 +1,282 @@
+{
+  "id": "9dc88c2b-801c-4803-9abc-dd04e7ffb81c",
+  "prevId": "0c9bd3bc-3a26-4acd-9a44-d7af12d99bfe",
+  "version": "6",
+  "dialect": "sqlite",
+  "tables": {
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "columns": [
+            "key_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "environments": {
+      "name": "environments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "environments_project_id_name_unique": {
+          "name": "environments_project_id_name_unique",
+          "columns": [
+            "project_id",
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "environments_project_id_projects_id_fk": {
+          "name": "environments_project_id_projects_id_fk",
+          "tableFrom": "environments",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "tableTo": "projects",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_name_unique": {
+          "name": "projects_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "secrets": {
+      "name": "secrets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_encrypted": {
+          "name": "key_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value_encrypted": {
+          "name": "value_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "secrets_environment_id_key_hash_unique": {
+          "name": "secrets_environment_id_key_hash_unique",
+          "columns": [
+            "environment_id",
+            "key_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "secrets_environment_id_environments_id_fk": {
+          "name": "secrets_environment_id_environments_id_fk",
+          "tableFrom": "secrets",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "tableTo": "environments",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/server/migrations/meta/_journal.json
+++ b/packages/server/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1772729285928,
       "tag": "0000_init",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1772927546068,
+      "tag": "0001_plaintext-project-config-names",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/db/queries.ts
+++ b/packages/server/src/db/queries.ts
@@ -92,14 +92,14 @@ export async function updateKeyLastUsed(
 
 // ─── Projects ───
 
-export async function getProjectByHash(
+export async function getProjectByName(
   db: DrizzleD1Database,
-  nameHash: string
+  name: string
 ): Promise<ProjectRow | undefined> {
   const rows = await db
     .select()
     .from(projects)
-    .where(eq(projects.nameHash, nameHash))
+    .where(eq(projects.name, name))
     .limit(1);
   return rows[0];
 }
@@ -157,10 +157,10 @@ export async function deleteProject(
 
 // ─── Environments ───
 
-export async function getEnvironmentByHash(
+export async function getEnvironmentByName(
   db: DrizzleD1Database,
   projectId: string,
-  nameHash: string
+  name: string
 ): Promise<EnvironmentRow | undefined> {
   const rows = await db
     .select()
@@ -168,7 +168,7 @@ export async function getEnvironmentByHash(
     .where(
       and(
         eq(environments.projectId, projectId),
-        eq(environments.nameHash, nameHash)
+        eq(environments.name, name)
       )
     )
     .limit(1);

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -19,8 +19,7 @@ export const apiKeys = sqliteTable("api_keys", {
 
 export const projects = sqliteTable("projects", {
   id: text("id").primaryKey(),
-  nameEncrypted: text("name_encrypted").notNull(),
-  nameHash: text("name_hash").notNull().unique(),
+  name: text("name").notNull().unique(),
   createdAt: text("created_at").notNull(),
 });
 
@@ -33,14 +32,13 @@ export const environments = sqliteTable(
     projectId: text("project_id")
       .notNull()
       .references(() => projects.id, { onDelete: "cascade" }),
-    nameEncrypted: text("name_encrypted").notNull(),
-    nameHash: text("name_hash").notNull(),
+    name: text("name").notNull(),
     createdAt: text("created_at").notNull(),
   },
   (table) => [
-    uniqueIndex("environments_project_id_name_hash_unique").on(
+    uniqueIndex("environments_project_id_name_unique").on(
       table.projectId,
-      table.nameHash
+      table.name
     ),
   ]
 );

--- a/packages/server/src/routes/configs.ts
+++ b/packages/server/src/routes/configs.ts
@@ -4,11 +4,9 @@ import type {
   ListConfigsResponse,
 } from "@keyflare/shared";
 import type { DrizzleD1Database } from "drizzle-orm/d1";
-import { encrypt, decrypt } from "../crypto/encrypt.js";
-import { hmacSha256 } from "../crypto/hash.js";
 import {
-  getProjectByHash,
-  getEnvironmentByHash,
+  getProjectByName,
+  getEnvironmentByName,
   listEnvironments,
   insertEnvironment,
   deleteEnvironment,
@@ -21,11 +19,10 @@ import { isUserKey, hasScope } from "../middleware/auth.js";
 /** Resolve a project by name → { id, name } or return error Response. */
 export async function resolveProject(
   db: DrizzleD1Database,
-  derivedKeys: DerivedKeys,
+  _derivedKeys: DerivedKeys,
   projectName: string
 ): Promise<{ id: string; name: string } | Response> {
-  const nameHash = await hmacSha256(derivedKeys.hmacKey, projectName);
-  const project = await getProjectByHash(db, nameHash);
+  const project = await getProjectByName(db, projectName);
   if (!project) {
     return jsonError("NOT_FOUND", `Project "${projectName}" not found`, 404);
   }
@@ -35,12 +32,11 @@ export async function resolveProject(
 /** Resolve an environment by name within a project → { id, name } or error Response. */
 export async function resolveEnvironment(
   db: DrizzleD1Database,
-  derivedKeys: DerivedKeys,
+  _derivedKeys: DerivedKeys,
   projectId: string,
   configName: string
 ): Promise<{ id: string; name: string } | Response> {
-  const nameHash = await hmacSha256(derivedKeys.hmacKey, configName);
-  const environment = await getEnvironmentByHash(db, projectId, nameHash);
+  const environment = await getEnvironmentByName(db, projectId, configName);
   if (!environment) {
     return jsonError("NOT_FOUND", `Config "${configName}" not found`, 404);
   }
@@ -71,14 +67,12 @@ export async function handleCreateConfig(
   if (projectResult instanceof Response) return projectResult;
 
   const name = body.name.trim();
-  const nameHash = await hmacSha256(derivedKeys.hmacKey, name);
-  const nameEncrypted = await encrypt(derivedKeys.encryptionKey, name);
 
   // Check for duplicate
-  const existing = await getEnvironmentByHash(
+  const existing = await getEnvironmentByName(
     db,
     projectResult.id,
-    nameHash
+    name
   );
   if (existing) {
     return jsonError(
@@ -94,8 +88,7 @@ export async function handleCreateConfig(
   await insertEnvironment(db, {
     id,
     projectId: projectResult.id,
-    nameEncrypted,
-    nameHash,
+    name,
     createdAt: now,
   });
 
@@ -124,12 +117,7 @@ export async function handleListConfigs(
   const configs = [];
 
   for (const row of rows) {
-    let name: string;
-    try {
-      name = await decrypt(derivedKeys.encryptionKey, row.nameEncrypted);
-    } catch {
-      name = "(decryption failed)";
-    }
+    const name = row.name;
 
     // If system key, filter by scope
     if (auth.keyType === "system") {

--- a/packages/server/src/routes/projects.ts
+++ b/packages/server/src/routes/projects.ts
@@ -5,10 +5,8 @@ import type {
   DeleteProjectResponse,
 } from "@keyflare/shared";
 import type { DrizzleD1Database } from "drizzle-orm/d1";
-import { encrypt, decrypt } from "../crypto/encrypt.js";
-import { hmacSha256 } from "../crypto/hash.js";
 import {
-  getProjectByHash,
+  getProjectByName,
   listProjects,
   insertProject,
   insertEnvironment,
@@ -23,7 +21,7 @@ export async function handleCreateProject(
   request: Request,
   db: DrizzleD1Database,
   auth: AuthContext,
-  derivedKeys: DerivedKeys
+  _derivedKeys: DerivedKeys
 ): Promise<Response> {
   if (!isUserKey(auth)) {
     return jsonError("FORBIDDEN", "Only user keys can create projects", 403);
@@ -36,11 +34,9 @@ export async function handleCreateProject(
 
   const name = body.name.trim();
   const environmentless = body.environmentless === true;
-  const nameHash = await hmacSha256(derivedKeys.hmacKey, name);
-  const nameEncrypted = await encrypt(derivedKeys.encryptionKey, name);
 
   // Check for duplicate
-  const existing = await getProjectByHash(db, nameHash);
+  const existing = await getProjectByName(db, name);
   if (existing) {
     return jsonError("CONFLICT", `Project "${name}" already exists`, 409);
   }
@@ -50,24 +46,17 @@ export async function handleCreateProject(
 
   await insertProject(db, {
     id,
-    nameEncrypted,
-    nameHash,
+    name,
     createdAt: now,
   });
 
   if (!environmentless) {
     const defaultEnvNames = ["Dev", "Prod"];
     for (const envName of defaultEnvNames) {
-      const envNameHash = await hmacSha256(derivedKeys.hmacKey, envName);
-      const envNameEncrypted = await encrypt(
-        derivedKeys.encryptionKey,
-        envName
-      );
       await insertEnvironment(db, {
         id: crypto.randomUUID(),
         projectId: id,
-        nameEncrypted: envNameEncrypted,
-        nameHash: envNameHash,
+        name: envName,
         createdAt: now,
       });
     }
@@ -80,18 +69,13 @@ export async function handleListProjects(
   request: Request,
   db: DrizzleD1Database,
   auth: AuthContext,
-  derivedKeys: DerivedKeys
+  _derivedKeys: DerivedKeys
 ): Promise<Response> {
   const rows = await listProjects(db);
   const projects = [];
 
   for (const row of rows) {
-    let name: string;
-    try {
-      name = await decrypt(derivedKeys.encryptionKey, row.nameEncrypted);
-    } catch {
-      name = "(decryption failed)";
-    }
+    const name = row.name;
 
     // If system key, filter to scoped projects only
     if (auth.keyType === "system" && auth.scopes) {
@@ -114,15 +98,14 @@ export async function handleDeleteProject(
   request: Request,
   db: DrizzleD1Database,
   auth: AuthContext,
-  derivedKeys: DerivedKeys,
+  _derivedKeys: DerivedKeys,
   projectName: string
 ): Promise<Response> {
   if (!isUserKey(auth)) {
     return jsonError("FORBIDDEN", "Only user keys can delete projects", 403);
   }
 
-  const nameHash = await hmacSha256(derivedKeys.hmacKey, projectName);
-  const project = await getProjectByHash(db, nameHash);
+  const project = await getProjectByName(db, projectName);
   if (!project) {
     return jsonError("NOT_FOUND", `Project "${projectName}" not found`, 404);
   }


### PR DESCRIPTION
## Summary
- stop encrypting and hashing project/config names; projects and environments now store plaintext `name` columns and use direct name lookups
- keep encryption/hashing where it matters: secret keys/values remain AES-256-GCM encrypted, API key auth remains SHA-256, and `secrets.key_hash` remains HMAC-SHA256 for upsert/lookups
- add migration `0001_plaintext-project-config-names.sql` as a destructive reset of `projects`, `environments`, and `secrets` tables, and update architecture/security/development docs and diagrams accordingly

## Breaking change
- this migration drops and recreates `projects`, `environments`, and `secrets` tables
- existing project/config/secret rows are deleted when applying migration `0001`

## Validation
- `pnpm --filter @keyflare/server typecheck`
- `pnpm --filter @keyflare/server lint`
- `pnpm --filter @keyflare/server test`