### PR TITLE
fix: align CLI zod-openapi version with server to resolve peer dependency warnings

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,7 +32,7 @@
     "ora": "^9.3.0",
     "wrangler": "^4.71.0",
     "zod": "^3.25.76",
-    "zod-openapi": "^5.4.6"
+    "zod-openapi": "^4.2.4"
   },
   "devDependencies": {
     "@keyflare/shared": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,7 +50,7 @@ importers:
         version: 4.12.5
       hono-openapi:
         specifier: ^1.3.0
-        version: 1.3.0(@hono/standard-validator@0.2.2(@standard-schema/spec@1.1.0)(hono@4.12.5))(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(arktype@2.1.27)(quansync@0.2.11)(zod@3.25.76))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(arktype@2.1.27)(quansync@0.2.11)(zod@3.25.76))(@standard-schema/spec@1.1.0)(arktype@2.1.27)(openapi-types@12.1.3)(zod-openapi@5.4.6(zod@3.25.76))(zod@3.25.76))(@types/json-schema@7.0.15)(hono@4.12.5)(openapi-types@12.1.3)
+        version: 1.3.0(@hono/standard-validator@0.2.2(@standard-schema/spec@1.1.0)(hono@4.12.5))(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(arktype@2.1.27)(quansync@0.2.11)(zod@3.25.76))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(arktype@2.1.27)(quansync@0.2.11)(zod@3.25.76))(@standard-schema/spec@1.1.0)(arktype@2.1.27)(openapi-types@12.1.3)(zod-openapi@4.2.4(zod@3.25.76))(zod@3.25.76))(@types/json-schema@7.0.15)(hono@4.12.5)(openapi-types@12.1.3)
       open:
         specifier: ^11.0.0
         version: 11.0.0
@@ -64,8 +64,8 @@ importers:
         specifier: ^3.25.76
         version: 3.25.76
       zod-openapi:
-        specifier: ^5.4.6
-        version: 5.4.6(zod@3.25.76)
+        specifier: ^4.2.4
+        version: 4.2.4(zod@3.25.76)
     devDependencies:
       '@keyflare/shared':
         specifier: workspace:*
@@ -5776,12 +5776,6 @@ packages:
     peerDependencies:
       zod: ^3.21.4
 
-  zod-openapi@5.4.6:
-    resolution: {integrity: sha512-P2jsOOBAq/6hCwUsMCjUATZ8szkMsV5VAwZENfyxp2Hc/XPJQpVwAgevWZc65xZauCwWB9LAn7zYeiCJFAEL+A==}
-    engines: {node: '>=20'}
-    peerDependencies:
-      zod: ^3.25.74 || ^4.0.0
-
   zod-to-json-schema@3.20.4:
     resolution: {integrity: sha512-Un9+kInJ2Zt63n6Z7mLqBifzzPcOyX+b+Exuzf7L1+xqck9Q2EPByyTRduV3kmSPaXaRer1JCsucubpgL1fipg==}
     peerDependencies:
@@ -7579,16 +7573,6 @@ snapshots:
       zod: 3.25.76
       zod-openapi: 4.2.4(zod@3.25.76)
 
-  '@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(arktype@2.1.27)(quansync@0.2.11)(zod@3.25.76))(@standard-schema/spec@1.1.0)(arktype@2.1.27)(openapi-types@12.1.3)(zod-openapi@5.4.6(zod@3.25.76))(zod@3.25.76)':
-    dependencies:
-      '@standard-community/standard-json': 0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(arktype@2.1.27)(quansync@0.2.11)(zod@3.25.76)
-      '@standard-schema/spec': 1.1.0
-      openapi-types: 12.1.3
-    optionalDependencies:
-      arktype: 2.1.27
-      zod: 3.25.76
-      zod-openapi: 5.4.6(zod@3.25.76)
-
   '@standard-schema/spec@1.1.0': {}
 
   '@stoplight/better-ajv-errors@1.0.3(ajv@8.18.0)':
@@ -9366,16 +9350,6 @@ snapshots:
     dependencies:
       '@standard-community/standard-json': 0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(arktype@2.1.27)(quansync@0.2.11)(zod@3.25.76)
       '@standard-community/standard-openapi': 0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(arktype@2.1.27)(quansync@0.2.11)(zod@3.25.76))(@standard-schema/spec@1.1.0)(arktype@2.1.27)(openapi-types@12.1.3)(zod-openapi@4.2.4(zod@3.25.76))(zod@3.25.76)
-      '@types/json-schema': 7.0.15
-      openapi-types: 12.1.3
-    optionalDependencies:
-      '@hono/standard-validator': 0.2.2(@standard-schema/spec@1.1.0)(hono@4.12.5)
-      hono: 4.12.5
-
-  hono-openapi@1.3.0(@hono/standard-validator@0.2.2(@standard-schema/spec@1.1.0)(hono@4.12.5))(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(arktype@2.1.27)(quansync@0.2.11)(zod@3.25.76))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(arktype@2.1.27)(quansync@0.2.11)(zod@3.25.76))(@standard-schema/spec@1.1.0)(arktype@2.1.27)(openapi-types@12.1.3)(zod-openapi@5.4.6(zod@3.25.76))(zod@3.25.76))(@types/json-schema@7.0.15)(hono@4.12.5)(openapi-types@12.1.3):
-    dependencies:
-      '@standard-community/standard-json': 0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(arktype@2.1.27)(quansync@0.2.11)(zod@3.25.76)
-      '@standard-community/standard-openapi': 0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(arktype@2.1.27)(quansync@0.2.11)(zod@3.25.76))(@standard-schema/spec@1.1.0)(arktype@2.1.27)(openapi-types@12.1.3)(zod-openapi@5.4.6(zod@3.25.76))(zod@3.25.76)
       '@types/json-schema': 7.0.15
       openapi-types: 12.1.3
     optionalDependencies:
@@ -12289,10 +12263,6 @@ snapshots:
       youch-core: 0.3.3
 
   zod-openapi@4.2.4(zod@3.25.76):
-    dependencies:
-      zod: 3.25.76
-
-  zod-openapi@5.4.6(zod@3.25.76):
     dependencies:
       zod: 3.25.76
 


### PR DESCRIPTION
## Summary

- Downgrade `zod-openapi` in `packages/cli/package.json` from `^5.4.6` to `^4.2.4` to match the server package and satisfy the `@standard-community/standard-openapi` peer dependency constraint (`zod-openapi@^4`)

## Context

The CLI doesn't import `zod-openapi` directly — it's only listed as a dependency so that wrangler/esbuild can resolve it when building the bundled server source at deploy time. The server uses `zod-openapi@^4.2.4`, but the CLI had `^5.4.6`, causing `ERESOLVE` warnings on `npm install -g @keyflare/cli` because the transitive dependency chain `hono-openapi → @standard-community/standard-openapi` requires `zod-openapi@^4`.

No upstream fix exists — `@standard-community/standard-openapi@0.2.9` is the latest version and hasn't widened its peer dependency to accept v5.

Closes #11