### PR TITLE
fix: quote wildcard scopes in CLI help text and docs

### DIFF
--- a/docs/guides/api-keys.mdx
+++ b/docs/guides/api-keys.mdx
@@ -87,7 +87,7 @@ kfl keys create --type system \
   kfl keys create --type system --scope "my-api:*" --permission read
   
   # Wrong (Zsh error: "no matches found")
-  kfl keys create --type system --scope my-api:* --permission read
+  kfl keys create --type system --scope "my-api:*" --permission read
   ```
 </Note>
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -271,7 +271,7 @@ keys
       "  - Can only access specific project/environment combinations.\n" +
       "  - Required flags: --type system --label <label> --scope <project:env> --permission <read|readwrite>\n" +
       "  - Use --scope multiple times for multiple project:env pairs.\n" +
-      "  - Use * as environment wildcard (e.g., --scope my-api:*)"
+      '  - Use * as environment wildcard (e.g., --scope "my-api:*")'
   )
   .requiredOption("--type <type>", "Key type: user or system")
   .requiredOption("--label <label>", "Human-readable label")
@@ -302,8 +302,8 @@ keys
     "Update the scopes and permission of a system key.\n\n" +
       "This replaces ALL existing scopes with the new set. Use `kfl keys list` to see current scopes.\n\n" +
       "Examples:\n" +
-      "  kfl keys put kfl_sys_abc123 --scope my-api:production --permission read\n" +
-      "  kfl keys put kfl_sys_abc123 --scope my-api:* --scope frontend:* --permission readwrite"
+      '  kfl keys put kfl_sys_abc123 --scope "my-api:production" --permission read\n' +
+      '  kfl keys put kfl_sys_abc123 --scope "my-api:*" --scope "frontend:*" --permission readwrite'
   )
   .requiredOption(
     "--scope <scope>",


### PR DESCRIPTION
## Summary

- Adds missing quotes around wildcard scope values (e.g. `"my-api:*"`) in CLI help text for `kfl keys create` and `kfl keys put`
- Fixes the same issue in `docs/guides/api-keys.mdx` where the \"Wrong\" example was accidentally using the correct (quoted) value

Without quotes, shells like Zsh perform glob expansion on `my-api:*` and fail with `no matches found`.