### PR TITLE
feat: support detailed secret descriptions

### DIFF
--- a/packages/server/migrations/0002_adorable_exiles.sql
+++ b/packages/server/migrations/0002_adorable_exiles.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `secrets` ADD `description_encrypted` text;

--- a/packages/server/migrations/meta/0002_snapshot.json
+++ b/packages/server/migrations/meta/0002_snapshot.json
@@ -1,0 +1,296 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "b8b883fb-809a-417c-8c89-7ba185db3cee",
+  "prevId": "2a79f4ff-f33e-49d1-992c-94693ac0309f",
+  "tables": {
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "columns": [
+            "key_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "environments": {
+      "name": "environments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "environments_project_id_name_unique": {
+          "name": "environments_project_id_name_unique",
+          "columns": [
+            "project_id",
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "environments_project_id_projects_id_fk": {
+          "name": "environments_project_id_projects_id_fk",
+          "tableFrom": "environments",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_name_unique": {
+          "name": "projects_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "secrets": {
+      "name": "secrets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_encrypted": {
+          "name": "key_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value_encrypted": {
+          "name": "value_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description_encrypted": {
+          "name": "description_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "secrets_environment_id_key_hash_unique": {
+          "name": "secrets_environment_id_key_hash_unique",
+          "columns": [
+            "environment_id",
+            "key_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "secrets_environment_id_environments_id_fk": {
+          "name": "secrets_environment_id_environments_id_fk",
+          "tableFrom": "secrets",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/server/migrations/meta/_journal.json
+++ b/packages/server/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1773313045683,
       "tag": "0001_striped_sue_storm",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1782411868259,
+      "tag": "0002_adorable_exiles",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/db/queries.ts
+++ b/packages/server/src/db/queries.ts
@@ -237,6 +237,7 @@ export async function upsertSecret(
       set: {
         keyEncrypted: params.keyEncrypted,
         valueEncrypted: params.valueEncrypted,
+        descriptionEncrypted: params.descriptionEncrypted,
         updatedAt: params.updatedAt,
       },
     });
@@ -249,6 +250,21 @@ export async function deleteSecretByHash(
 ): Promise<boolean> {
   const result = await db
     .delete(secrets)
+    .where(
+      and(eq(secrets.environmentId, environmentId), eq(secrets.keyHash, keyHash))
+    );
+  return (result.meta?.changes ?? 0) > 0;
+}
+
+export async function updateSecretDescriptionByHash(
+  db: DrizzleD1Database,
+  environmentId: string,
+  keyHash: string,
+  descriptionEncrypted: string | null
+): Promise<boolean> {
+  const result = await db
+    .update(secrets)
+    .set({ descriptionEncrypted, updatedAt: new Date().toISOString() })
     .where(
       and(eq(secrets.environmentId, environmentId), eq(secrets.keyHash, keyHash))
     );

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -56,6 +56,7 @@ export const secrets = sqliteTable(
     keyEncrypted: text("key_encrypted").notNull(),
     keyHash: text("key_hash").notNull(),
     valueEncrypted: text("value_encrypted").notNull(),
+    descriptionEncrypted: text("description_encrypted"),
     updatedAt: text("updated_at").notNull(),
   },
   (table) => [

--- a/packages/server/src/routes/secrets.ts
+++ b/packages/server/src/routes/secrets.ts
@@ -12,6 +12,7 @@ import {
   deleteSecretByHash,
   deleteAllSecrets,
   countSecrets,
+  updateSecretDescriptionByHash,
 } from "../db/queries.js";
 import type { AuthContext, DerivedKeys } from "../types.js";
 import { jsonOk, jsonError } from "../utils.js";
@@ -45,6 +46,7 @@ export async function handleGetSecrets(
 
   const rows = await getSecretsByEnvironment(db, envResult.id);
   const secrets: Record<string, string> = {};
+  const descriptions: Record<string, string> = {};
 
   for (const row of rows) {
     try {
@@ -54,12 +56,19 @@ export async function handleGetSecrets(
         row.valueEncrypted
       );
       secrets[key] = value;
+      if (row.descriptionEncrypted) {
+        descriptions[key] = await decrypt(derivedKeys.encryptionKey, row.descriptionEncrypted);
+      }
     } catch {
       // Skip corrupted secrets
     }
   }
 
-  return jsonOk<GetSecretsResponse>({ secrets });
+  const response: GetSecretsResponse = { secrets };
+  if (Object.keys(descriptions).length > 0) {
+    response.descriptions = descriptions;
+  }
+  return jsonOk<GetSecretsResponse>(response);
 }
 
 export async function handleSetSecrets(
@@ -107,12 +116,18 @@ export async function handleSetSecrets(
     const keyHash = await hmacSha256(derivedKeys.hmacKey, key);
     const valueEncrypted = await encrypt(derivedKeys.encryptionKey, String(value));
 
+    let descriptionEncrypted: string | null = null;
+    if (body.descriptions && body.descriptions[key]) {
+      descriptionEncrypted = await encrypt(derivedKeys.encryptionKey, body.descriptions[key]);
+    }
+
     await upsertSecret(db, {
       id: crypto.randomUUID(),
       environmentId: envResult.id,
       keyEncrypted,
       keyHash,
       valueEncrypted,
+      descriptionEncrypted,
       updatedAt: now,
     });
     count++;
@@ -173,15 +188,33 @@ export async function handlePatchSecrets(
         String(value)
       );
 
+      let descriptionEncrypted: string | null | undefined = undefined;
+      if (body.descriptions && key in body.descriptions) {
+        const desc = body.descriptions[key];
+        descriptionEncrypted = desc ? await encrypt(derivedKeys.encryptionKey, desc) : null;
+      }
+
       await upsertSecret(db, {
         id: crypto.randomUUID(),
         environmentId: envResult.id,
         keyEncrypted,
         keyHash,
         valueEncrypted,
+        descriptionEncrypted,
         updatedAt: now,
       });
       setCount++;
+    }
+  }
+
+  // Update standalone descriptions
+  if (body.descriptions) {
+    for (const [key, desc] of Object.entries(body.descriptions)) {
+      if (body.set && key in body.set) continue;
+      
+      const keyHash = await hmacSha256(derivedKeys.hmacKey, key);
+      const descriptionEncrypted = desc ? await encrypt(derivedKeys.encryptionKey, desc) : null;
+      await updateSecretDescriptionByHash(db, envResult.id, keyHash, descriptionEncrypted);
     }
   }
 

--- a/packages/server/src/validation/schemas.ts
+++ b/packages/server/src/validation/schemas.ts
@@ -61,17 +61,19 @@ export const updateKeySchema = z
 export const setSecretsSchema = z
   .object({
     secrets: z.record(z.string()),
+    descriptions: z.record(z.string()).optional(),
   })
   .strict();
 
 export const patchSecretsSchema = z
   .object({
     set: z.record(z.string()).optional(),
+    descriptions: z.record(z.string().nullable()).optional(),
     delete: z.array(nonEmptyString).optional(),
   })
   .strict()
-  .refine((value) => value.set !== undefined || value.delete !== undefined, {
-    message: "At least one of 'set' or 'delete' is required",
+  .refine((value) => value.set !== undefined || value.delete !== undefined || value.descriptions !== undefined, {
+    message: "At least one of 'set', 'descriptions', or 'delete' is required",
   });
 
 export type CreateProjectInput = z.infer<typeof createProjectSchema>;

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -164,10 +164,12 @@ export interface ListEnvironmentsResponse {
 
 export interface GetSecretsResponse {
   secrets: Record<string, string>;
+  descriptions?: Record<string, string>;
 }
 
 export interface SetSecretsRequest {
   secrets: Record<string, string>;
+  descriptions?: Record<string, string>;
 }
 
 export interface SetSecretsResponse {
@@ -178,6 +180,7 @@ export interface SetSecretsResponse {
 
 export interface PatchSecretsRequest {
   set?: Record<string, string>;
+  descriptions?: Record<string, string | null>;
   delete?: string[];
 }
 


### PR DESCRIPTION
This PR adds support for fetching, patching, and storing detailed descriptions for secrets in Keyflare. Resolves the issue where Zod was rejecting the 'descriptions' payload and properly stores it in D1.